### PR TITLE
New --simple flag for SNS Testing (only return the valid object, not all the other permutations)

### DIFF
--- a/bin/jstdgen
+++ b/bin/jstdgen
@@ -2,7 +2,7 @@
 'use strict';
 
 var path = require('path');
-var generate = require('../dist');
+var jst = require('../dist');
 var param = process.argv[2];
 var fs = require('fs');
 var version = require('../package.json').version;
@@ -12,6 +12,14 @@ var parser = new ArgumentParser({
   addHelp:true,
   description: 'Tool that generates test data from provided Schema'
 });
+
+parser.addArgument(
+  ['--simple', '-s'],
+  {
+    help: 'Generate single, valid JSON payload',
+    action: 'storeTrue'
+  }
+);
 
 parser.addArgument(
   ['-v', '--version'],
@@ -55,4 +63,9 @@ try {
   process.exit(234);
 }
 
-console.log(JSON.stringify(generate(schema)));
+if (!args.simple) {
+  var payload = jst.generate(schema);
+} else {
+  var payload = jst.generate_simple(schema);
+}
+console.log(JSON.stringify(payload));

--- a/bin/jstdgen
+++ b/bin/jstdgen
@@ -1,33 +1,52 @@
 #!/usr/bin/env node
+'use strict';
 
 var path = require('path');
 var generate = require('../dist');
 var param = process.argv[2];
 var fs = require('fs');
 var version = require('../package.json').version;
+var ArgumentParser = require('argparse').ArgumentParser;
 
-if (!param) {
-  console.log('must specify a schema file');
-  process.exit(234);
-}
+var parser = new ArgumentParser({
+  addHelp:true,
+  description: 'Tool that generates test data from provided Schema'
+});
 
-if (param === '-v' || param === '--version') {
+parser.addArgument(
+  ['-v', '--version'],
+  {
+    help: 'Print version',
+    action: 'storeTrue'
+  }
+);
+
+parser.addArgument(
+  ['schema_file'],
+  {
+    help: 'Path to JSON Schema'
+  }
+);
+
+var args = parser.parseArgs()
+
+if (args.version) {
   console.log(version);
   process.exit(0);
 }
 
-if (param === '-h' || param === '--help') {
-  console.log('Usage:\n\tjstdgen schema.json');
-  process.exit(0);
+if (!args.schema_file) {
+  console.log('must specify a schema file');
+  process.exit(234);
 }
 
-var ext = path.extname(param);
+var ext = path.extname(args.schema_file);
 if (!ext || ext !== '.json') {
   console.log('must specify a schema file');
   process.exit(234);
 }
 
-var schemaStr = fs.readFileSync(param, 'utf8');
+var schemaStr = fs.readFileSync(args.schema_file, 'utf8');
 var schema;
 try {
   schema = JSON.parse(schemaStr);

--- a/lib/index.js
+++ b/lib/index.js
@@ -441,5 +441,29 @@ function generate(schema) {
   return ret;
 }
 
+/**
+ * Generates single data object based on JSON schema
+ * @param  {Object} schema Fully expanded (no <code>$ref</code>) JSON Schema
+ * @return {Object} a valid test data object
+ */
+function generate_simple(schema) {
+  const ret = {};
+  if (!validate(schema)) {
+    return ret;
+  }
+
+  const fullSample = jsf(schema);
+  if (!fullSample) {
+    return ret;
+  }
+
+  for (const [ key, value ] of Object.entries(fullSample)) {
+    ret[key] = JSON.stringify(fullSample[key]);
+  }
+
+  return ret;
+}
+
 generate.getNegativeTypes = getNegativeTypes;
-module.exports = generate;
+module.exports.generate = generate;
+module.exports.generate_simple = generate_simple;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "json-schema-test-data-generator",
   "description": "Generate sample test data based on JSON schema",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "homepage": "https://github.com/bojand/json-schema-test-data-generator",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "chance": "~1.0.0",
     "json-schema-faker": "^0.2.15",
     "lodash": "^4.7.0",
-    "prop-search": "~1.0.0"
+    "prop-search": "~1.0.0",
+    "argparse": "~1.0.10"
   },
   "devDependencies": {
     "ava": "~0.13.0",

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 import test from 'ava';
-import generate from '../dist/index';
+const jst = require('../dist/index');
 import _ from 'lodash';
 const validator = require('validator');
 
@@ -7,7 +7,7 @@ const userSchema = require('./user.json');
 
 test('should generate test data with differnte variations based on required property', t => {
   const required = userSchema.required;
-  const data = generate(userSchema);
+  const data = jst.generate(userSchema);
 
   // should have data that has all required fields
   let found = _.some(data, d => {
@@ -34,13 +34,13 @@ test('should generate test data with differnte variations based on required prop
 
 test('should generate test data with negative type tests for simple primitive data types', t => {
   const required = userSchema.required;
-  const data = generate(userSchema);
+  const data = jst.generate(userSchema);
 
   required.forEach(req => {
     const found = _.chain(data)
       .filter(d => (d.valid === false) && (d.property && d.property === req) && (typeof d.data[req] !== 'undefined'))
       .some(d => {
-        const types = generate.getNegativeTypes(userSchema.properties[req]);
+        const types = jst.generate.getNegativeTypes(userSchema.properties[req]);
         const dataType = d.data[req] === null ? 'null' : typeof d.data[req];
         const check = types.indexOf(dataType) >= 0;
         return check;
@@ -64,7 +64,7 @@ test('should create negative for number multipleOf', t => {
     required: ['foo']
   };
 
-  const data = generate(schema);
+  const data = jst.generate(schema);
   const required = schema.required;
 
   required.forEach(req => {
@@ -92,7 +92,7 @@ test('should create negative for number maximum', t => {
     }
   };
 
-  const data = generate(schema);
+  const data = jst.generate(schema);
   const found = _.chain(data)
     .filter(d => d.valid === false && typeof d.data.foo === 'number')
     .some(d => d.data.foo && d.data.foo > 3)
@@ -114,7 +114,7 @@ test('should create negative for number minimum', t => {
     }
   };
 
-  const data = generate(schema);
+  const data = jst.generate(schema);
   const found = _.chain(data)
     .filter(d => d.valid === false && typeof d.data.foo === 'number')
     .some(d => d.data.foo && d.data.foo < 3)
@@ -136,7 +136,7 @@ test('should create negative for string maxLength', t => {
     }
   };
 
-  const data = generate(schema);
+  const data = jst.generate(schema);
   const found = _.chain(data)
     .filter(d => d.valid === false && typeof d.data.foo === 'string')
     .some(d => d.data.foo && d.data.foo.length > 5)
@@ -158,7 +158,7 @@ test('should create negative for string minLength', t => {
     }
   };
 
-  const data = generate(schema);
+  const data = jst.generate(schema);
   const found = _.chain(data)
     .filter(d => d.valid === false && typeof d.data.foo === 'string')
     .some(d => d.data.foo && d.data.foo.length < 5)
@@ -180,7 +180,7 @@ test('should create negative for string pattern date-time', t => {
     }
   };
 
-  const data = generate(schema);
+  const data = jst.generate(schema);
   const found = _.chain(data)
     .filter(d => d.valid === false && typeof d.data.foo === 'string')
     .some(d => d.data.foo && isNaN(Date.parse(d.data.foo)))
@@ -202,7 +202,7 @@ test('should create negative for string pattern email', t => {
     }
   };
 
-  const data = generate(schema);
+  const data = jst.generate(schema);
   const found = _.chain(data)
     .filter(d => d.valid === false && typeof d.data.foo === 'string')
     .some(d => d.data.foo && !validator.isEmail(d.data.foo))
@@ -224,7 +224,7 @@ test('should create negative for string pattern uri', t => {
     }
   };
 
-  const data = generate(schema);
+  const data = jst.generate(schema);
   const found = _.chain(data)
     .filter(d => d.valid === false && typeof d.data.foo === 'string')
     .some(d => d.data.foo && !validator.isURL(d.data.foo))
@@ -249,7 +249,7 @@ test('should create negative for array property maxItems', t => {
     }
   };
 
-  const data = generate(schema);
+  const data = jst.generate(schema);
   const found = _.chain(data)
     .filter(d => d.valid === false && Array.isArray(d.data.foo))
     .some(d => d.data.foo && d.data.foo.length > 5)
@@ -274,7 +274,7 @@ test('should create negative for array property minItems', t => {
     }
   };
 
-  const data = generate(schema);
+  const data = jst.generate(schema);
   const found = _.chain(data)
     .filter(d => d.valid === false && Array.isArray(d.data.foo))
     .some(d => d.data.foo && d.data.foo.length < 5)
@@ -299,7 +299,7 @@ test('should create negative for array property uniqueItems', t => {
     }
   };
 
-  const data = generate(schema);
+  const data = jst.generate(schema);
   const found = _.chain(data)
     .filter(d => d.valid === false && Array.isArray(d.data.foo))
     .some(d => d.data.foo && _.uniq(d.data.foo).length < d.data.foo.length)
@@ -315,7 +315,7 @@ test('should create negative simple type schema', t => {
     type: 'string'
   };
 
-  const data = generate(schema);
+  const data = jst.generate(schema);
 
   const found = _.chain(data)
     .filter(d => d.valid === false)
@@ -333,7 +333,7 @@ test('should create negative simple type schema and additional properties', t =>
     minimum: 5
   };
 
-  const data = generate(schema);
+  const data = jst.generate(schema);
 
   const found = _.chain(data)
     .filter(d => d.valid === false)
@@ -363,7 +363,7 @@ test('should create negative test data for schema with array', t => {
     required: ['name', 'foos']
   };
 
-  const data = generate(schema);
+  const data = jst.generate(schema);
 
   const found = _.chain(data)
     .filter(d => d.valid === false && d.data && Array.isArray(d.data.foos))
@@ -394,7 +394,7 @@ test('should create negative test data for schema with array and minItems proper
     required: ['name', 'foos']
   };
 
-  const data = generate(schema);
+  const data = jst.generate(schema);
 
   const found = _.chain(data)
     .filter(d => d.valid === false && d.data && Array.isArray(d.data.foos))
@@ -426,7 +426,7 @@ test('should create negative test data for nested object property', t => {
     required: ['name', 'foo']
   };
 
-  const data = generate(schema);
+  const data = jst.generate(schema);
 
   const found = _.chain(data)
     .filter(d => d.valid === false && d.data && d.data.foo && typeof d.data.foo.bar !== 'undefined')
@@ -436,4 +436,14 @@ test('should create negative test data for nested object property', t => {
   t.is(found.length, 2);
 
   t.pass();
+});
+
+test('generate_simple: should generate a single test data object all required fields', t => {
+  const required = userSchema.required;
+  const data = jst.generate_simple(userSchema);
+
+  // should have data that has all required fields
+  const keys = Object.keys(data);
+  const diff = _.difference(required, keys);
+  t.true(diff.length === 0);
 });


### PR DESCRIPTION
I've been using the output of this tool to pipe data into other tools (mostly copy-pasta into AWS's SNS Console... for Push Notification testing)

This new feature serializes the nested objects in a way that can be ingested by AWS's Push Notification Schema
